### PR TITLE
fix: 用pagehide替代浏览器不再支持的unload

### DIFF
--- a/src/component/message_iframe/render_message.ts
+++ b/src/component/message_iframe/render_message.ts
@@ -468,7 +468,7 @@ export function destroyIframe(iframe: HTMLIFrameElement): void {
     }
   }
 
-  $iframe.trigger('unload').remove();
+  $iframe.remove();
 
   if (window._observedElements?.size === 0 && window._sharedResizeObserver) {
     window._sharedResizeObserver.disconnect();

--- a/src/component/prompt_view/index.ts
+++ b/src/component/prompt_view/index.ts
@@ -37,6 +37,6 @@ export async function initPromptView(): Promise<void> {
 /**
  * 页面卸载时清理所有事件监听器
  */
-$(window).on('unload', () => {
+$(window).on('pagehide', () => {
   eventSource.removeListener(event_types.CHAT_COMPLETION_PROMPT_READY, onChatCompletionPromptReady);
 });

--- a/src/iframe_client/event.ts
+++ b/src/iframe_client/event.ts
@@ -428,5 +428,5 @@ namespace detail {
 
   export const waiting_event_map: ArrayMultimap<string, number> = new ArrayMultimap();
 
-  $(window).on('unload', eventClearAll);
+  $(window).on('pagehide', eventClearAll);
 }


### PR DESCRIPTION
文档中
```
如果要在脚本关闭时执行功能，请使用 $('unload',()=>{})
```
需要相应修改