### PR TITLE
fix: 修复重roll消息时无法获取变量的问题

### DIFF
--- a/src/function/macro_like.ts
+++ b/src/function/macro_like.ts
@@ -29,7 +29,7 @@ export const macros: MacroLike[] = [
               type,
               message_id:
                 context.message_id ??
-                chat.findLastIndex(message => _.isObject(_.get(message, ['variables', _.get(message, 'swipe_id', 0)]))),
+                chat.findLastIndex(message => _.isObject(message.variables?.[message.swipe_id ?? 0])),
             },
       );
       const value = omitDeepBy(_.get(variables, _.unescape(path), null), (_, key) => key.startsWith('$'));
@@ -52,7 +52,7 @@ export const macros: MacroLike[] = [
               type,
               message_id:
                 context.message_id ??
-                chat.findLastIndex(message => _.isObject(_.get(message, ['variables', _.get(message, 'swipe_id', 0)]))),
+                chat.findLastIndex(message => _.isObject(message.variables?.[message.swipe_id ?? 0])),
             },
       );
       const value = omitDeepBy(_.get(variables, _.unescape(path), null), (_, key) => key.startsWith('$'));


### PR DESCRIPTION
很显然，在MVU中只要重roll消息就无法获取变量。这是由于：

重roll消息之后，酒馆助手原来的代码试图通过“消息是否有variables”来判断它是否是最后一条有变量的消息。

但这是有问题的。

假设原来的消息只有一个swipe（swipes的长度为1），其id为0。

重roll消息后，消息增加了id为1的swipe，但swipes的长度仍然为1，该id为1的swipe并不存在。

此时，该消息当然有变量（是属于0号swipe的变量），但获取变量会获取1号swipe的变量，得到null。