### PR TITLE
fix: 修复 cleanup_protector.js 中的语法错误

### DIFF
--- a/src/iframe/cleanup_protector.js
+++ b/src/iframe/cleanup_protector.js
@@ -314,4 +314,4 @@ $(window).on('pagehide', () => {
   if (iframeObserver) {
     iframeObserver.disconnect();
   }
-};);
+});


### PR DESCRIPTION
修复了一个导致实验性功能“兜底清理”无法生效的语法错误。

在 `src/iframe/cleanup_protector.js` 最末尾，闭合括号写成了 `};);`，导致浏览器解析时抛出 `SyntaxError: missing ) after argument list` 异常，使整个兜底清理代理无法正常注册。

本 PR 将其修正为了 `});`。