### PR TITLE
fix(deps): upgrade lodash to 4.18.1 (CVE-2026-4800)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   figlet: 1.11.2
+  lodash: 4.18.1
 
 importers:
 
@@ -55,7 +56,7 @@ importers:
         version: 2.0.6
       lodash-omitdeep:
         specifier: ^1.10.1
-        version: 1.10.1(lodash@4.17.21)
+        version: 1.10.1(lodash@4.18.1)
       object-to-formdata:
         specifier: ^4.5.1
         version: 4.5.1
@@ -2034,10 +2035,10 @@ packages:
   lodash-omitdeep@1.10.1:
     resolution: {integrity: sha512-jOXkpZfHZaxjPlvdKBQZhb2mg7lMClIM6o8loA0tjbDjuv7N/2sGg1qUhdP9mg7zt3y2i0GOQSdqPPQL8pPy+w==}
     peerDependencies:
-      lodash: ^4
+      lodash: 4.18.1
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   magic-string-ast@1.0.3:
     resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
@@ -4616,11 +4617,11 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
-  lodash-omitdeep@1.10.1(lodash@4.17.21):
+  lodash-omitdeep@1.10.1(lodash@4.18.1):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
 
-  lodash@4.17.21: {}
+  lodash@4.18.1: {}
 
   magic-string-ast@1.0.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ allowBuilds:
   vue-demi: true
 overrides:
   figlet: 1.11.2
+  lodash: 4.18.1
 onlyBuiltDependencies:
   - '@parcel/watcher'
   - '@tailwindcss/oxide'


### PR DESCRIPTION
简而言之就是最近lodash有个[CVE-2026-4800](https://github.com/advisories/GHSA-r5fr-rjxr-66jc)影响，修复 TauriTavern 的过程中顺便排查了下，发现 酒馆助手 通过 `lodash-omitdeep` 间接依赖 `lodash@4.17.21`，因此会受到该CVE影响。`lodash-es` 目前已经是 `4.18.1`，不在受影响范围内。

对此的改动为：
- 在现有 pnpm overrides 中将 `lodash` 固定为 `4.18.1`。
- 更新 `pnpm-lock.yaml`。

`lodash-omitdeep` 支持 Lodash 4，这次升级不会改变原有接口和行为。`pnpm audit` 已不再报告相关漏洞，构建通过。